### PR TITLE
Npm adjustments

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "tsc-compile:chart": "tsc --outDir ./code/js ./code/ts-src/BaseChart.ts --target es5",
     "tsc-compile": "npm run tsc-compile:linear && npm run tsc-compile:chart",
     "build": "npm run sass && npm run tsc-compile",
-    "start": "npm build && parallelshell 'npm run tsc-compile:chart -- -w' 'npm run sass -- -w' 'npm run browser-sync'",
+    "start": "npm run build && parallelshell 'npm run tsc-compile:chart -- -w' 'npm run sass -- -w' 'npm run browser-sync'",
     "postinstall": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -32,15 +32,13 @@
   },
   "homepage": "https://github.com/CodeForFoco/solar-scorecard#readme",
   "dependencies": {
+    "browser-sync": "^2.18.12",
     "d3": "^4.9.1",
     "d3-axis": "^1.0.7",
     "d3-scale": "^1.0.6",
     "d3-selection": "^1.1.0",
     "node-sass": "4.5.3",
-    "parallelshell": "3.0.1"
-  },
-  "devDependencies": {
-    "browser-sync": "^2.18.12",
+    "parallelshell": "3.0.1",
     "typescript": "^2.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "Solar Scorecard project: track Fort Collins renewable/solar energy goals.",
   "main": "index.js",
   "scripts": {
-    "browser-sync": "browser-sync start --server --files=$npm_package_config_bsync --open external --startPath ./code/projections.html",
+    "browser-sync": "browser-sync start --server --directory --files=$npm_package_config_bsync --open external --startPath ./code",
     "sass": "node-sass -q --source-map true code/scss/main.scss code/css/main.css",
     "tsc-compile:linear": "tsc ./code/linear_model/stats.ts --target es5",
     "tsc-compile:chart": "tsc --outDir ./code/js ./code/ts-src/BaseChart.ts --target es5",


### PR DESCRIPTION
- Use `dependencies` for all npm deps for now
- Also we have a few different HTML files now and I forget their paths and they aren't linked to each other, so the easy way out is to use browser-sync's `--directories` option: 

![screen shot 2017-06-26 at 9 17 06 pm](https://user-images.githubusercontent.com/4974087/27569598-9a2801a2-5ab5-11e7-8526-92657ab5de14.jpg)
