### PR TITLE
Publish to GitHub Pages demo site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # :sunny: :sunny: Fort Collins Solar Scorecard :sunny: :sunny:
 
+Demo: http://codeforfoco.org/solar-scorecard/stairstep.html
+
 Solar Scorecard project: track Fort Collins renewable/solar energy goals.
 
 ## Goal of Project
@@ -66,6 +68,9 @@ TL;DR Contribution Workflow:
 1. Commit your changes. Push your changes to your fork on GitHub.
 1. Submit a new [pull request][pullrequest] and your changes will be reviewed and merged.
 
+### Publishing
+If you are administrator of the main repository and want to push to the [demo site][gh-demo]: `npm run publish-gh-pages`.
+
 ## Repository Organization
 This repo is structured as follows:
 
@@ -98,3 +103,4 @@ MIT, see [LICENSE](/LICENSE) for full license.
 [newissue]: https://github.com/CodeForFoco/solar-scorecard/issues/new
 [pullrequest]: https://github.com/CodeForFoco/solar-scorecard/pulls
 [node]: https://nodejs.org/en/
+[gh-demo]: http://codeforfoco.org/solar-scorecard/stairstep.html

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build": "npm run sass && npm run tsc-compile",
     "start": "npm run build && parallelshell 'npm run tsc-compile -- -w' 'npm run sass -- -w' 'npm run browser-sync'",
     "postinstall": "npm run build",
+    "publish-gh-pages": "node publish-gh-pages.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
@@ -37,6 +38,7 @@
     "d3-axis": "^1.0.7",
     "d3-scale": "^1.0.6",
     "d3-selection": "^1.1.0",
+    "gh-pages": "^1.0.0",
     "node-sass": "4.5.3",
     "parallelshell": "3.0.1",
     "typescript": "^2.3.4"

--- a/publish-gh-pages.js
+++ b/publish-gh-pages.js
@@ -1,0 +1,3 @@
+var ghpages = require('gh-pages');
+
+ghpages.publish('code', function(err) {});


### PR DESCRIPTION
Closes #2 

If one of you with admin rights to this repo has a chance, try this if you are not pushing to a fork:

```
npm run publish-gh-pages
```

...and the demo/output of that will be here: http://codeforfoco.org/solar-scorecard/stairstep.html

We can make an index.html later, then point to individual examples if that makes sense.