### PR TITLE
Move code/stairstep.html to index.html 

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,12 +3,12 @@
 <head>
   <meta charset="utf-8">
   <title>Stairstep Chart</title>
-  <script type="text/javascript" src="js/chartjs/Chart.min.js"></script>
-  <script type="text/javascript" src="js-compiled/Stats.js"></script>
-  <script type="text/javascript" src="js/util.js"></script>
-  <script type="text/javascript" src="js/Tabs.js"></script>
-  <script type="text/javascript" src="js/StairstepChart.js"></script>
-  <link rel="stylesheet" type="text/css" href="css/main.css">
+  <script type="text/javascript" src="code/js/chartjs/Chart.min.js"></script>
+  <script type="text/javascript" src="code/js-compiled/Stats.js"></script>
+  <script type="text/javascript" src="code/js/util.js"></script>
+  <script type="text/javascript" src="code/js/Tabs.js"></script>
+  <script type="text/javascript" src="code/js/StairstepChart.js"></script>
+  <link rel="stylesheet" type="text/css" href="code/css/main.css">
 
   <script>
     var demodata = util.toProjectionFormat(util.generateDummyData());

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "solar-scorecard",
   "config": {
-    "bsync": "./code/**/*.html ./code/**/*.css ./code/**/*.js"
+    "bsync": "*.html ./code/**/*.html ./code/**/*.css ./code/**/*.js"
   },
   "version": "0.1.0",
   "private": true,
   "description": "Solar Scorecard project: track Fort Collins renewable/solar energy goals.",
   "main": "index.js",
   "scripts": {
-    "browser-sync": "browser-sync start --server --directory --files=$npm_package_config_bsync --open external --startPath ./code",
+    "browser-sync": "browser-sync start --server --files=$npm_package_config_bsync --open external",
     "sass": "node-sass -q --source-map true code/scss/main.scss code/css/main.css",
     "tsc-compile:linear": "tsc --outDir ./code/js-compiled ./code/linear_model/Stats.ts --target es5",
     "tsc-compile": "npm run tsc-compile:linear",


### PR DESCRIPTION
Closes #26 

Rather than having a separate *index.html* page, I just `git mv`ed *code/stairstep.html*. If things get more complicated later we can switch to a landing page approach, but a single page should suffice for now.